### PR TITLE
Fix `drop_percentage` testing

### DIFF
--- a/experiment_api/experiment.py
+++ b/experiment_api/experiment.py
@@ -244,7 +244,7 @@ def should_drop(drop_percentage):
     Returns:
         a boolean whether to drop or not drop the image
     """
-    return random.randrange(100) < (100 - drop_percentage * 100)
+    return random.random() < drop_percentage
 
 # -----------------------------------------------------------------------------
 #  Execution example


### PR DESCRIPTION
`drop_percentage` is a float from [0,1], so we can use `random.random()`
to generate a number from [0, 1). If the number is smaller than the drop
percentage, drop the car from the set.