### PR TITLE
Change how `set_type` is set in `ChipDataset()`

### DIFF
--- a/pelops/datasets/chip.py
+++ b/pelops/datasets/chip.py
@@ -10,7 +10,7 @@ import pelops.utils as utils
 
 class DatasetFactory(object):
     @staticmethod
-    def create_dataset(dataset_type, dataset_path, set_type=utils.SetType.ALL.value):
+    def create_dataset(dataset_type, dataset_path, set_type=None):
         for cls in ChipDataset.__subclasses__():
             if cls.check_dataset_type(dataset_type):
                 return cls(dataset_path, set_type)
@@ -21,12 +21,34 @@ class DatasetFactory(object):
 
 
 class ChipDataset(metaclass = abc.ABCMeta):
-    def __init__(self, dataset_path, set_type=utils.SetType.ALL.value):
+    def __init__(self, dataset_path, set_type=None):
         self.dataset_path = dataset_path
-        self.set_type = set_type
+        self.__set_set_type(set_type)
         self.chips = dict()
         self.chips_by_cam_id = None
         self.chips_by_car_id = None
+
+    def __set_set_type(self, set_type):
+        self.set_type = None
+
+        # The Default ALL
+        if set_type is None:
+            self.set_type = utils.SetType.ALL
+
+        # If passed a SetType
+        if isinstance(set_type, utils.SetType):
+            self.set_type = set_type
+
+        # If passed a string
+        if isinstance(set_type, str):
+            set_type = set_type.lower()
+            for st in utils.SetType:
+                if set_type == st.value:
+                    self.set_type = st
+
+        if self.set_type is None:
+            raise ValueError("set_type is not a valid string or SetType enum")
+
 
     @classmethod
     def check_dataset_type(self, dataset_type):

--- a/pelops/datasets/compcar.py
+++ b/pelops/datasets/compcar.py
@@ -25,7 +25,7 @@ class CompcarDataset(chip.ChipDataset):
         "color_list.mat",
     )
 
-    def __init__(self, dataset_path, set_type=utils.SetType.ALL.value):
+    def __init__(self, dataset_path, set_type=None):
         super().__init__(dataset_path, set_type)
         self.__set_filepaths()         # set self.__filepaths
         self.__extract_color_labels()  # set self.__color_map
@@ -95,9 +95,9 @@ class CompcarDataset(chip.ChipDataset):
     def __set_chips(self):
         # identify all the chips, default query to all
         all_names_filepaths = {
-            utils.SetType.ALL.value: [self.__filepaths.name_test, self.__filepaths.name_train], 
-            utils.SetType.TEST.value: [self.__filepaths.name_test],
-            utils.SetType.TRAIN.value: [self.__filepaths.name_train],
+            utils.SetType.ALL: [self.__filepaths.name_test, self.__filepaths.name_train],
+            utils.SetType.TEST: [self.__filepaths.name_test],
+            utils.SetType.TRAIN: [self.__filepaths.name_train],
         }.get(self.set_type, [self.__filepaths.name_test, self.__filepaths.name_train])
         # create chip objects based on the names listed in the files
         for name_filepath in all_names_filepaths:

--- a/pelops/datasets/dgcars.py
+++ b/pelops/datasets/dgcars.py
@@ -21,7 +21,7 @@ class DGCarsDataset(chip.ChipDataset):
         "testing",
     )
 
-    def __init__(self, dataset_path, set_type=utils.SetType.ALL.value):
+    def __init__(self, dataset_path, set_type=None):
         super().__init__(dataset_path, set_type)
         self.__set_filepaths()         # set self.__filepaths
         self.__set_chips()
@@ -36,9 +36,9 @@ class DGCarsDataset(chip.ChipDataset):
     def __set_chips(self):
         # identify all the chips, default query to all
         name_filepath = {
-            utils.SetType.ALL.value: self.__filepaths.all_list,
-            utils.SetType.TEST.value: self.__filepaths.test_list,
-            utils.SetType.TRAIN.value: self.__filepaths.train_list,
+            utils.SetType.ALL: self.__filepaths.all_list,
+            utils.SetType.TEST: self.__filepaths.test_list,
+            utils.SetType.TRAIN: self.__filepaths.train_list,
         }.get(self.set_type, self.__filepaths.all_list)
 
         # create chip objects based on the names listed in the files

--- a/pelops/datasets/str.py
+++ b/pelops/datasets/str.py
@@ -13,7 +13,7 @@ import pelops.utils as utils
 class StrDataset(chip.ChipDataset):
     # define paths to files and directories
     filenames = collections.namedtuple(
-        "filenames", 
+        "filenames",
         [
             "dir_all"
         ]
@@ -22,7 +22,7 @@ class StrDataset(chip.ChipDataset):
         "crossCameraMatches"
     )
 
-    def __init__(self, dataset_path, set_type=utils.SetType.ALL.value):
+    def __init__(self, dataset_path, set_type=None):
         super().__init__(dataset_path, set_type)
         self.__set_filepaths()  # set self.__filepaths
         self.__set_chips()

--- a/pelops/datasets/veri.py
+++ b/pelops/datasets/veri.py
@@ -41,7 +41,7 @@ class VeriDataset(chip.ChipDataset):
         "train_label.txt"
     )
 
-    def __init__(self, dataset_path, set_type=utils.SetType.ALL.value):
+    def __init__(self, dataset_path, set_type=None):
         super().__init__(dataset_path, set_type)
         self.__set_filepaths()  # set self.__filepaths
         self.__set_chips()
@@ -64,10 +64,10 @@ class VeriDataset(chip.ChipDataset):
         # TODO: ignore images labeled as query, so we do not have to keep tabs for identical chips
         # identify all the chips
         all_names_filepaths = {
-            utils.SetType.ALL.value: [self.__filepaths.name_query, self.__filepaths.name_test, self.__filepaths.name_train],
-            utils.SetType.QUERY.value: [self.__filepaths.name_query],
-            utils.SetType.TEST.value: [self.__filepaths.name_test],
-            utils.SetType.TRAIN.value: [self.__filepaths.name_train],
+            utils.SetType.ALL: [self.__filepaths.name_query, self.__filepaths.name_test, self.__filepaths.name_train],
+            utils.SetType.QUERY: [self.__filepaths.name_query],
+            utils.SetType.TEST: [self.__filepaths.name_test],
+            utils.SetType.TRAIN: [self.__filepaths.name_train],
         }.get(self.set_type)
         # create chip objects based on the names listed in the files
         for name_filepath in all_names_filepaths:

--- a/pelops/utils.py
+++ b/pelops/utils.py
@@ -12,10 +12,10 @@ import time
 class SetType(enum.Enum):
     """ Types of set, i.e. training set
     """
-    ALL = 0
-    QUERY = 1
-    TEST = 2
-    TRAIN = 3
+    ALL = "all"
+    QUERY = "query"
+    TEST = "test"
+    TRAIN = "train"
 
     
 def get_session(gpu_fraction=0.3):

--- a/testci/test_compcar.py
+++ b/testci/test_compcar.py
@@ -52,7 +52,7 @@ def compcar(tmpdir):
     name_test.write(names)
 
     # Setup the class
-    instantiated_class = CompcarDataset(name_test.dirname, utils.SetType.TEST.value)
+    instantiated_class = CompcarDataset(name_test.dirname, utils.SetType.TEST)
 
     # Rename filepath
     FILE_NAMES = (

--- a/testci/test_dgcars.py
+++ b/testci/test_dgcars.py
@@ -54,9 +54,9 @@ def dgcars(tmpdir):
 
     # Instantiate a DGCarsDataset() class
     output_classes = {
-        SetType.ALL: DGCarsDataset(tmpdir.strpath, SetType.ALL.value),
-        SetType.TRAIN: DGCarsDataset(tmpdir.strpath, SetType.TRAIN.value),
-        SetType.TEST: DGCarsDataset(tmpdir.strpath, SetType.TEST.value),
+        SetType.ALL: DGCarsDataset(tmpdir.strpath, SetType.ALL),
+        SetType.TRAIN: DGCarsDataset(tmpdir.strpath, SetType.TRAIN),
+        SetType.TEST: DGCarsDataset(tmpdir.strpath, SetType.TEST),
     }
 
     return (output_classes, output_chips)

--- a/testci/test_veri.py
+++ b/testci/test_veri.py
@@ -43,7 +43,7 @@ def veri(tmpdir):
     name_test.write(names)
 
     # Setup the class
-    instantiated_class = VeriDataset(name_test.dirname, utils.SetType.TEST.value)
+    instantiated_class = VeriDataset(name_test.dirname, utils.SetType.TEST)
 
     # Rename filepath
     FILE_NAMES = (


### PR DESCRIPTION
Previously it was set with an integer from the `SetType` enum. It is now
set with the enum itself, or a string describing the set ("train",
"test", etc.). `None` is now the default value in the constructor, which
defaults to `SetType.ALL`. All checks have been changed to assume that
an acutal `SetType` object is stored in the class.

This still needs some tests in insure we don't break it again...