### PR TITLE
Ensure filepath is a string lookup

### DIFF
--- a/pelops/datasets/featuredataset.py
+++ b/pelops/datasets/featuredataset.py
@@ -13,7 +13,10 @@ class FeatureDataset(ChipDataset):
             self.filename_lookup[chip.filepath] = chip_key
     
     def get_feats_for_chip(self, chip):
-        chip_key = self.filename_lookup[chip.filepath]
+        filepath = chip.filepath
+        if isinstance(filepath, bytes):
+            filepath = filepath.decode('utf-8')
+        chip_key = self.filename_lookup[filepath]
         return self.feats[self.chip_index_lookup[chip_key]]
     
     @staticmethod


### PR DESCRIPTION
Modify get_feats_for_chip to assume the key will always be a string (vs bytes)